### PR TITLE
Vertex struct

### DIFF
--- a/MyGameMaker/MyGameEditor/Root.cpp
+++ b/MyGameMaker/MyGameEditor/Root.cpp
@@ -292,12 +292,12 @@ void Root::CreateGameObjectWithPath(const std::string& path)
 		std::shared_ptr<BoundingBox> meshBBox = std::make_shared<BoundingBox>();
 		
 
-        meshBBox->min = meshRenderer->GetMesh()->getModel()->GetModelData().vertexData.front();
-        meshBBox->max = meshRenderer->GetMesh()->getModel()->GetModelData().vertexData.front();
+        meshBBox->min = meshRenderer->GetMesh()->getModel()->GetModelData().vertexData.front().position;
+        meshBBox->max = meshRenderer->GetMesh()->getModel()->GetModelData().vertexData.front().position;
 
         for (const auto& v : meshRenderer->GetMesh()->getModel()->GetModelData().vertexData) {
-            meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v));
-            meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v));
+            meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v.position));
+            meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v.position));
         }
 
         go->GetComponent<MeshRenderer>()->GetMesh()->setBoundingBox(*meshBBox);

--- a/MyGameMaker/MyGameEngine/Mesh.cpp
+++ b/MyGameMaker/MyGameEngine/Mesh.cpp
@@ -161,15 +161,15 @@ std::shared_ptr<Mesh> Mesh::CreateCube()
 
 	model->GetModelData().vertexData = {
 		// Front face
-		vec3(-1.0f, -1.0f, 1.0f),
-		vec3(1.0f, -1.0f, 1.0f),
-		vec3(1.0f, 1.0f, 1.0f),
-		vec3(-1.0f, 1.0f, 1.0f),
+		Vertex{vec3(-1.0f, -1.0f, 1.0f)},
+		Vertex{vec3(1.0f, -1.0f, 1.0f)},
+		Vertex{vec3(1.0f, 1.0f, 1.0f)},
+		Vertex{vec3(-1.0f, 1.0f, 1.0f)},
 		// Back face
-		vec3(-1.0f, -1.0f, -1.0f),
-		vec3(1.0f, -1.0f, -1.0f),
-		vec3(1.0f, 1.0f, -1.0f),
-		vec3(-1.0f, 1.0f, -1.0f),
+		Vertex{vec3(-1.0f, -1.0f, -1.0f)},
+		Vertex{vec3(1.0f, -1.0f, -1.0f)},
+		Vertex{vec3(1.0f, 1.0f, -1.0f)},
+		Vertex{vec3(-1.0f, 1.0f, -1.0f)}
 	};
 
 	model->GetModelData().indexData = {
@@ -186,12 +186,12 @@ std::shared_ptr<Mesh> Mesh::CreateCube()
 	std::shared_ptr<BoundingBox> meshBBox = std::make_shared<BoundingBox>();
 
 
-	meshBBox->min = model->GetModelData().vertexData.front();
-	meshBBox->max = model->GetModelData().vertexData.front();
+	meshBBox->min = model->GetModelData().vertexData.front().position;
+	meshBBox->max = model->GetModelData().vertexData.front().position;
 
 	for (const auto& v : model->GetModelData().vertexData) {
-		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v));
-		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v));
+		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v.position));
+		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v.position));
 	}
 
 	mesh->setBoundingBox(*meshBBox);
@@ -223,15 +223,15 @@ std::shared_ptr<Mesh> Mesh::CreateCylinder() {
 		float z = radius * sin(angle);
 
 		// Base inferior
-		model->GetModelData().vertexData.emplace_back(x, -halfHeight, z);
+		//model->GetModelData().vertexData.emplace_back(x, -halfHeight, z);
 
-		// Base superior
-		model->GetModelData().vertexData.emplace_back(x, halfHeight, z);
+		//// Base superior
+		//model->GetModelData().vertexData.emplace_back(x, halfHeight, z);
 	}
 
 	// Añadir los vértices centrales de las bases
-	model->GetModelData().vertexData.emplace_back(0.0f, -halfHeight, 0.0f); // Centro base inferior
-	model->GetModelData().vertexData.emplace_back(0.0f, halfHeight, 0.0f);  // Centro base superior
+	//model->GetModelData().vertexData.emplace_back(0.0f, -halfHeight, 0.0f); // Centro base inferior
+	//model->GetModelData().vertexData.emplace_back(0.0f, halfHeight, 0.0f);  // Centro base superior
 
 	// Generar índices para los lados del cilindro
 	for (int i = 0; i < slices; ++i) {
@@ -270,12 +270,12 @@ std::shared_ptr<Mesh> Mesh::CreateCylinder() {
 	std::shared_ptr<BoundingBox> meshBBox = std::make_shared<BoundingBox>();
 
 
-	meshBBox->min = model->GetModelData().vertexData.front();
-	meshBBox->max = model->GetModelData().vertexData.front();
+	meshBBox->min = model->GetModelData().vertexData.front().position;
+	meshBBox->max = model->GetModelData().vertexData.front().position;
 
 	for (const auto& v : model->GetModelData().vertexData) {
-		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v));
-		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v));
+		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v.position));
+		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v.position));
 	}
 
 	mesh->setBoundingBox(*meshBBox);
@@ -309,7 +309,11 @@ std::shared_ptr<Mesh> Mesh::CreateSphere()
 			float y = cos(phi);
 			float z = sin(theta) * sin(phi);
 
-			model->GetModelData().vertexData.push_back(glm::vec3(x, y, z) * radius);
+			Vertex vertex;
+
+			vertex.position = glm::vec3(x, y, z) * radius;
+
+			model->GetModelData().vertexData.push_back(vertex);
 		}
 	}
 
@@ -328,12 +332,12 @@ std::shared_ptr<Mesh> Mesh::CreateSphere()
 	std::shared_ptr<BoundingBox> meshBBox = std::make_shared<BoundingBox>();
 
 
-	meshBBox->min = model->GetModelData().vertexData.front();
-	meshBBox->max = model->GetModelData().vertexData.front();
+	meshBBox->min = model->GetModelData().vertexData.front().position;
+	meshBBox->max = model->GetModelData().vertexData.front().position;
 
 	for (const auto& v : model->GetModelData().vertexData) {
-		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v));
-		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v));
+		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v.position));
+		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v.position));
 	}
 
 	mesh->setBoundingBox(*meshBBox);
@@ -351,10 +355,10 @@ std::shared_ptr<Mesh> Mesh::CreatePlane()
 	std::shared_ptr<Model> model = std::make_shared<Model>();
 
 	model->GetModelData().vertexData = {
-		vec3(-1.0f, 0.0f, 1.0f),
-		vec3(1.0f, 0.0f, 1.0f),
-		vec3(1.0f, 0.0f, -1.0f),
-		vec3(-1.0f, 0.0f, -1.0f)
+		Vertex {vec3(-1.0f, 0.0f, 1.0f)},
+		Vertex {vec3(1.0f, 0.0f, 1.0f)},
+		Vertex {vec3(1.0f, 0.0f, -1.0f)},
+		Vertex {vec3(-1.0f, 0.0f, -1.0f)}
 	};
 
 	model->GetModelData().indexData = {
@@ -366,12 +370,12 @@ std::shared_ptr<Mesh> Mesh::CreatePlane()
 	std::shared_ptr<BoundingBox> meshBBox = std::make_shared<BoundingBox>();
 
 
-	meshBBox->min = model->GetModelData().vertexData.front();
-	meshBBox->max = model->GetModelData().vertexData.front();
+	meshBBox->min = model->GetModelData().vertexData.front().position;
+	meshBBox->max = model->GetModelData().vertexData.front().position;
 
 	for (const auto& v : model->GetModelData().vertexData) {
-		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v));
-		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v));
+		meshBBox->min = glm::min(meshBBox->min, glm::dvec3(v.position));
+		meshBBox->max = glm::max(meshBBox->max, glm::dvec3(v.position));
 	}
 
 	mesh->setBoundingBox(*meshBBox);
@@ -457,10 +461,17 @@ void Mesh::loadToOpenGL()
 	(glGenVertexArrays(1, &model->GetModelData().vA));
 	(glBindVertexArray(model->GetModelData().vA));
 
+	std::vector<vec3> positions;
+
+	for (int i = 0; i < model->GetModelData().vertexData.size(); i++)
+	{
+		positions.push_back(model->GetModelData().vertexData[i].position);
+	}
+
 	//buffer de positions
 	(glGenBuffers(1, &model->GetModelData().vBPosID));
 	(glBindBuffer(GL_ARRAY_BUFFER, model->GetModelData().vBPosID));
-	(glBufferData(GL_ARRAY_BUFFER, model->GetModelData().vertexData.size() * sizeof(vec3), model->GetModelData().vertexData.data(), GL_STATIC_DRAW));
+	(glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(vec3), positions.data(), GL_STATIC_DRAW));
 
 	//position layout
 	(glEnableVertexAttribArray(0));
@@ -493,6 +504,8 @@ void Mesh::loadToOpenGL()
 		//loadNormalsToOpenGL();
 		//loadFaceNormalsToOpenGL();
 	}
+
+
 
 	//buffer de index
 	(glCreateBuffers(1, &model->GetModelData().iBID));

--- a/MyGameMaker/MyGameEngine/Model.cpp
+++ b/MyGameMaker/MyGameEngine/Model.cpp
@@ -1,11 +1,1 @@
 #include "Model.h"
-
-void Model::calculateBoundingBox()
-{
-    if (modelData.vertexData.empty()) {
-        m_BoundingBox = BoundingBox(); // Bounding box vacía si no hay vértices
-        return;
-    }
-    // Calcula la bounding box a partir de los vértices
-    m_BoundingBox = BoundingBox(modelData.vertexData.data(), modelData.vertexData.size());
-}

--- a/MyGameMaker/MyGameEngine/Model.h
+++ b/MyGameMaker/MyGameEngine/Model.h
@@ -6,6 +6,9 @@
 
 #include "types.h"
 
+#define MAX_BONE_INFLUENCE 4
+#define MAX_BONES 100
+
 enum class Shapes
 {
 	EMPTY,
@@ -18,10 +21,19 @@ enum class Shapes
 	MESH
 };
 
+struct Vertex
+{
+	vec3 position;
+
+	int m_BoneIDs[MAX_BONE_INFLUENCE];
+
+	float m_Weights[MAX_BONE_INFLUENCE];
+};
+
 struct ModelData
 {
 	unsigned int vBPosID = -1, vBNormalsID = -1, vBColorsID = -1, vBTCoordsID = -1, iBID = -1, vA = -1;
-	std::vector<vec3> vertexData;
+	std::vector<Vertex> vertexData;
 	std::vector<unsigned int> indexData;
 	std::vector<vec2> vertex_texCoords;
 	std::vector<vec3> vertex_normals;
@@ -42,7 +54,7 @@ public:
 
 	void SetModelData(const ModelData& modelData) {
 		this->modelData = modelData;
-		calculateBoundingBox(); // Recalcula la bounding box al actualizar los datos
+		//calculateBoundingBox(); // Recalcula la bounding box al actualizar los datos
 	}
 
 	void SetMaterialIndex(int index) { materialIndex = index; }
@@ -57,6 +69,6 @@ private:
 
 	BoundingBox m_BoundingBox; // Bounding box de la malla
 
-	void calculateBoundingBox(); // Método privado para calcular la bounding box
+	//void calculateBoundingBox(); // Método privado para calcular la bounding box
 };
 

--- a/MyGameMaker/MyGameEngine/ModelImporter.cpp
+++ b/MyGameMaker/MyGameEngine/ModelImporter.cpp
@@ -123,7 +123,9 @@ std::vector<std::shared_ptr<Mesh>>createMeshesFromFBX(const aiScene& scene) {
 			// Coordenadas de los vértices
 			aiVector3D vertex = mesh->mVertices[j];
 			vec3 aux = vec3(vertex.x, vertex.y, vertex.z);
-			modelsData[i]->vertexData.push_back(aux);
+			Vertex v;
+			v.position = aux;
+			modelsData[i]->vertexData.push_back(v);
 
 			// Coordenadas UV (si existen)
 			if (mesh->mTextureCoords[0]) {  // Comprueba si hay UVs


### PR DESCRIPTION
This pull request includes several changes to the `MyGameMaker` project, focusing on updating the `vertexData` structure to use a `Vertex` struct with a `position` member instead of using `vec3` directly. This change affects multiple methods for creating different shapes and their bounding boxes. Additionally, some unused code has been commented out.

### Changes to `vertexData` structure:

* Updated `vertexData` to use `Vertex` struct with `position` member in `Mesh::CreateCube()`, `Mesh::CreateCylinder()`, `Mesh::CreateSphere()`, and `Mesh::CreatePlane()` methods. [[1]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L164-R172) [[2]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L189-R194) [[3]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L226-R234) [[4]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L273-R278) [[5]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L312-R316) [[6]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L331-R340) [[7]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L354-R361) [[8]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L369-R378)

### Bounding box calculations:

* Modified bounding box calculations to use `vertex.position` instead of `vertex` directly in various methods. [[1]](diffhunk://#diff-1db1763febc7c7116c847b8c659b89f29d21eb20a64313fda084251c529ae69aL295-R300) [[2]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L189-R194) [[3]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L273-R278) [[4]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L331-R340) [[5]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5L369-R378)

### OpenGL loading:

* Adjusted `Mesh::loadToOpenGL()` method to extract positions from `vertexData` before buffering them to OpenGL. [[1]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5R464-R474) [[2]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5R508-R509)

### Removal of unused code:

* Removed the `Model::calculateBoundingBox` method and its calls since bounding box calculations are now handled differently. [[1]](diffhunk://#diff-e26e47d6c15c89b353f4c05bd8ee7859648ea2ed8556733f147a414bafc5ca8cL2-L11) [[2]](diffhunk://#diff-b4a9ad29dea09f28b4e3577229fbd0f6a789cebb8398cf35dd3609307abc2351L45-R57) [[3]](diffhunk://#diff-b4a9ad29dea09f28b4e3577229fbd0f6a789cebb8398cf35dd3609307abc2351L60-R72)

### Additional updates:

* Added `Vertex` struct definition and constants for bone influence and bones in `Model.h`. [[1]](diffhunk://#diff-b4a9ad29dea09f28b4e3577229fbd0f6a789cebb8398cf35dd3609307abc2351R9-R11) [[2]](diffhunk://#diff-b4a9ad29dea09f28b4e3577229fbd0f6a789cebb8398cf35dd3609307abc2351R24-R36)

These changes ensure that the vertex data structure is more flexible and consistent across different parts of the codebase, and they clean up unused code to improve maintainability.